### PR TITLE
Bug: submit handler not triggering

### DIFF
--- a/app/src/main/java/io/atomic/android_boilerplate/BoilerPlateViewModel.kt
+++ b/app/src/main/java/io/atomic/android_boilerplate/BoilerPlateViewModel.kt
@@ -26,6 +26,7 @@ class BoilerPlateViewModel : ViewModel() {
             cardListRefreshInterval = 30L
         }
         registerContainersForNotifications()
+        registerContainersWithHandlers()
     }
 
     private fun configureSdk() {
@@ -45,6 +46,18 @@ class BoilerPlateViewModel : ViewModel() {
 
         AACSDK.registerStreamContainersForNotifications(containers)
 
+    }
+
+    private fun registerContainersWithHandlers() {
+        streamContainer?.submitButtonWithPayloadActionHandler = { event ->
+            Log.d("Atomic", "Submit Callback triggered with payload: ${event.payload}")
+        }
+        streamContainer?.linkButtonWithPayloadActionHandler = { event ->
+            Log.d("Atomic", "Submit Callback triggered with payload: ${event.payload}")
+        }
+        streamContainer?.cardEventHandler = { event ->
+            Log.d("Atomic", "Submit Callback triggered with payload: ${event}")
+        }
     }
 
     companion object {


### PR DESCRIPTION
Send a card that had a submit button with a payload (ours has 4) and click the buttons

Event and Submit handlers should both trigger, but sometimes only event triggers